### PR TITLE
net: openthread: Use OT STORAGE flash partition

### DIFF
--- a/subsys/net/lib/openthread/platform/flash.c
+++ b/subsys/net/lib/openthread/platform/flash.c
@@ -22,7 +22,7 @@ otError utilsFlashInit(void)
 {
 	int i;
 	struct flash_pages_info info;
-	size_t pages_count;
+	u32_t ot_flash_index;
 
 	flash_dev = device_get_binding(DT_FLASH_DEV_NAME);
 
@@ -30,24 +30,27 @@ otError utilsFlashInit(void)
 		return OT_ERROR_NOT_IMPLEMENTED;
 	}
 
-	pages_count = flash_get_page_count(flash_dev);
-
-	if (flash_get_page_info_by_idx(flash_dev,
-		pages_count - CONFIG_OT_PLAT_FLASH_PAGES_COUNT - 1, &info)) {
-
+	if (flash_get_page_info_by_offs(flash_dev,
+					DT_FLASH_AREA_OT_STORAGE_OFFSET,
+					&info)) {
 		return OT_ERROR_FAILED;
 	}
 
+	ot_flash_index = info.index;
 	ot_flash_offset = info.start_offset;
 	ot_flash_size = 0;
 
 	for (i = 0; i < CONFIG_OT_PLAT_FLASH_PAGES_COUNT; i++) {
 		if (flash_get_page_info_by_idx(flash_dev,
-			pages_count - i - 1, &info)) {
+			ot_flash_index + i, &info)) {
 
 			return OT_ERROR_FAILED;
 		}
 		ot_flash_size += info.size;
+	}
+
+	if (ot_flash_size > DT_FLASH_AREA_OT_STORAGE_SIZE) {
+		return OT_ERROR_FAILED;
 	}
 
 	return OT_ERROR_NONE;


### PR DESCRIPTION
Use ot-storage flash sub-partition to store openthread settings instead
of placing it in the last pages of flash.

The OpenThread requires the defined sub-partition to be at least 2
pages big.

This change is necessary as some boards use the end of the flash to
store DFU and MBR data.

Signed-off-by: Joao Cordeiro <jvcc@cesar.org.br>