### PR TITLE
boards: arm: add knot_mesh

### DIFF
--- a/boards/arm/knot_mesh/CMakeLists.txt
+++ b/boards/arm/knot_mesh/CMakeLists.txt
@@ -1,0 +1,13 @@
+#
+# Code based on nrf52840_pca10059.
+# Base commit: 3ae52624ffa129dfd1b0f5dc337afd1ddd6c4c1c
+# Edited by KNoT contributors.
+#
+
+# Copyright (c) 2019 CESAR
+#
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+zephyr_library_sources(board.c)
+zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)

--- a/boards/arm/knot_mesh/Kconfig
+++ b/boards/arm/knot_mesh/Kconfig
@@ -1,0 +1,28 @@
+#
+# Code based on nrf52840_pca10059.
+# Base commit: b8d3ee8afb49d27c3e0c2aba946629620f3f3dd0
+# Edited by KNoT contributors.
+#
+
+# Kconfig - KNoT Mesh board configuration
+#
+# Copyright (c) 2019 CESAR
+# Copyright (c) 2018 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_KNOT_MESH
+
+config BOARD_ENABLE_DCDC
+        bool "Enable DCDC mode"
+        select SOC_DCDC_NRF52X
+        default y
+
+config BOARD_HAS_NRF5_BOOTLOADER
+	bool "Board has nRF5 bootloader"
+	default y
+	help
+	 If selected, applications are linked so that they can be loaded by
+	 Nordic nRF5 bootloader.
+
+endif # BOARD_KNOT_MESH

--- a/boards/arm/knot_mesh/Kconfig.board
+++ b/boards/arm/knot_mesh/Kconfig.board
@@ -1,0 +1,16 @@
+#
+# Code based on nrf52840_pca10059.
+# Base commit: ef935898d0bb7eb45f464650d79a264b2c3b0e98
+# Edited by KNoT contributors.
+#
+
+# Kconfig - KNoT Mesh board configuration
+#
+# Copyright (c) 2019 CESAR
+# Copyright (c) 2018 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+config  BOARD_KNOT_MESH
+	bool "KNOT MESH"
+	depends on SOC_NRF52840_QIAA

--- a/boards/arm/knot_mesh/Kconfig.defconfig
+++ b/boards/arm/knot_mesh/Kconfig.defconfig
@@ -1,0 +1,78 @@
+#
+# Code based on nrf52840_pca10059.
+# Base commit: 500fa722fb4ae971f2f0668bc02af9c001168e42
+# Edited by KNoT contributors.
+#
+
+# Kconfig - KNoT Mesh board configuration
+#
+# Copyright (c) 2019 CESAR
+# Copyright (c) 2018 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_KNOT_MESH
+
+config BOARD
+	default "knot_mesh"
+
+if BOARD_HAS_NRF5_BOOTLOADER && !USE_CODE_PARTITION
+
+# To let the nRF5 bootloader load an application, the application
+# must be linked after Nordic MBR, that is factory-programmed on the board.
+
+# Nordic nRF5 booatloader exists outside of the partitions specified in the
+# DTS file, so we manually override FLASH_LOAD_OFFEST to link the application
+# correctly, after Nordic MBR.
+
+# When building MCUBoot, MCUBoot itself will select USE_CODE_PARTITION
+# which will make it link into the correct partition specified in DTS file,
+# so no override is necessary.
+
+config FLASH_LOAD_OFFSET
+        default 0x1000
+
+endif # BOARD_HAS_NRF5_BOOTLOADER && !USE_CODE_PARTITION
+
+if ADC
+
+config ADC_0
+	default y
+
+endif # ADC
+
+if I2C
+
+config I2C_0
+	default y
+
+endif # I2C
+
+if SPI
+
+config SPI_1
+	default y
+
+endif # SPI
+
+if USB
+
+config USB_NRF52840
+	default y
+
+config USB_DEVICE_STACK
+	default y
+
+endif # USB
+
+if IEEE802154
+
+config IEEE802154_NRF5
+	default y
+
+endif # IEEE802154
+
+config BT_CTLR
+	default BT
+
+endif # BOARD_KNOT_MESH

--- a/boards/arm/knot_mesh/board.c
+++ b/boards/arm/knot_mesh/board.c
@@ -1,0 +1,51 @@
+/*
+ * Code based on nrf52840_pca10059.
+ * Base commit: aacdd64584c6e2d8800129ab2829d735fe23f74d
+ * Edited by KNoT contributors.
+ */
+/*
+ * Copyright (c) 2019 CESAR.
+ * Copyright (c) 2018 Nordic Semiconductor ASA.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <init.h>
+#include <nrf_power.h>
+
+static int board_knot_mesh_init(struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	/* if the knot_mesh board is powered from USB
+	 * (high voltage mode), GPIO output voltage is set to 1.8 volts by
+	 * default and that is not enough to turn the green and blue LEDs on.
+	 * Increase GPIO voltage to 3.0 volts.
+	 */
+	if ((nrf_power_mainregstatus_get() == NRF_POWER_MAINREGSTATUS_HIGH) &&
+	    ((NRF_UICR->REGOUT0 & UICR_REGOUT0_VOUT_Msk) ==
+	     (UICR_REGOUT0_VOUT_DEFAULT << UICR_REGOUT0_VOUT_Pos))) {
+
+		NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos;
+		while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {
+			;
+		}
+
+		NRF_UICR->REGOUT0 =
+		    (NRF_UICR->REGOUT0 & ~((uint32_t)UICR_REGOUT0_VOUT_Msk)) |
+		    (UICR_REGOUT0_VOUT_3V0 << UICR_REGOUT0_VOUT_Pos);
+
+		NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos;
+		while (NRF_NVMC->READY == NVMC_READY_READY_Busy) {
+			;
+		}
+
+		/* a reset is required for changes to take effect */
+		NVIC_SystemReset();
+	}
+
+	return 0;
+}
+
+SYS_INIT(board_knot_mesh_init, PRE_KERNEL_1,
+	 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/boards/arm/knot_mesh/board.cmake
+++ b/boards/arm/knot_mesh/board.cmake
@@ -1,0 +1,16 @@
+#
+# Code based on nrf52840_pca10059.
+# Base commit: 3ae52624ffa129dfd1b0f5dc337afd1ddd6c4c1c
+# Edited by KNoT contributors.
+#
+
+# Copyright (c) 2019 CESAR
+#
+# SPDX-License-Identifier: Apache-2.0
+
+board_runner_args(nrfjprog "--nrf-family=NRF52")
+board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(pyocd "--target=nrf52840")
+include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/knot_mesh/fstab-debugger.dts
+++ b/boards/arm/knot_mesh/fstab-debugger.dts
@@ -1,0 +1,46 @@
+/*
+ * Code based on nrf52840_pca10059.
+ * Base commit: a72f113bae77a7238e6366074e106f77375834c1
+ * Edited by KNoT contributors.
+ */
+/*
+ * Copyright (c) 2019 CESAR
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Flash partition table without support for Nordic nRF5 bootloader */
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* The size of this partition ensures that MCUBoot can be built
+		 * with an RTT console, CDC ACM support, and w/o optimizations.
+		 */
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x000000000 0x00012000>;
+		};
+
+		slot0_partition: partition@12000 {
+			label = "image-0";
+			reg = <0x00012000 0x000069000>;
+		};
+		slot1_partition: partition@7b000 {
+			label = "image-1";
+			reg = <0x0007b000 0x000069000>;
+		};
+		scratch_partition: partition@e4000 {
+			label = "image-scratch";
+			reg = <0x000e4000 0x00018000>;
+		};
+		storage_partition: partition@fc000 {
+			label = "storage";
+			reg = <0x000fc000 0x00004000>;
+		};
+	};
+};

--- a/boards/arm/knot_mesh/fstab-stock.dts
+++ b/boards/arm/knot_mesh/fstab-stock.dts
@@ -1,0 +1,53 @@
+/*
+ * Code based on nrf52840_pca10059.
+ * Base commit: 9661cbf9e5563403f291aef95a1f9f42b4f4ae60
+ * Edited by KNoT contributors.
+ */
+ /*
+ * Copyright (c) 2019 CESAR
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Flash partition table compatible with Nordic nRF5 bootloader */
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* MCUboot placed after Nordic MBR.
+		 * The size of this partition ensures that MCUBoot
+		 * can be built with CDC ACM support and w/o optimizations.
+		 */
+		boot_partition: partition@1000 {
+			label = "mcuboot";
+			reg = <0x00001000 0x000f000>;
+		};
+
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x00010000 0x00005e000>;
+		};
+		slot1_partition: partition@6d000 {
+			label = "image-1";
+			reg = <0x006e000 0x00005e000>;
+		};
+		storage_partition: partition@cc000 {
+			label = "storage";
+			reg = <0x000cc000 0x00004000>;
+		};
+		scratch_partition: partition@d0000 {
+			label = "image-scratch";
+			reg = <0x000d0000 0x00010000>;
+		};
+
+		/* Nordic nRF5 bootloader <0xe0000 0x1c000>
+		 *
+		 * In addition, the last and second last flash pages
+		 * are used by the nRF5 bootloader and MBR to store settings.
+		 */
+	};
+};

--- a/boards/arm/knot_mesh/knot_mesh.dts
+++ b/boards/arm/knot_mesh/knot_mesh.dts
@@ -1,0 +1,118 @@
+/*
+ * Code based on nrf52840_pca10059.
+ * Base commit: c616f215b0e04376d80320e32988eb763738a65b
+ * Edited by KNoT contributors.
+ */
+
+/*
+ * Copyright (c) 2019 CESAR
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ * Copyright (c) 2017 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include <nordic/nrf52840_qiaa.dtsi>
+
+/ {
+	model = "KNoT Mesh Dev Kit";
+	compatible = "nordic,nrf52840-qiaa", "nordic,nrf52840";
+
+	chosen {
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+		zephyr,uart-mcumgr = &uart0;
+		zephyr,bt-mon-uart = &uart0;
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led0: led_0 {
+			gpios = <&gpio0 14 GPIO_INT_ACTIVE_LOW>;
+			label = "Status LED";
+		};
+		led1: led_1 {
+			gpios = <&gpio0 13 GPIO_INT_ACTIVE_LOW>;
+			label = "User LED";
+		};
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+		button0: button_0 {
+			gpios = <&gpio0 7 GPIO_PUD_PULL_UP>;
+			label = "Push button switch 0";
+		};
+		button1: button_1 {
+			gpios = <&gpio0 12 GPIO_PUD_PULL_UP>;
+			label = "Push button switch 1";
+		};
+	};
+
+	/* These aliases are provided for compatibility with samples */
+	aliases {
+		sw0 = &button0;
+		sw1 = &button1;
+		led0 = &led0;
+		led1 = &led1;
+		status-led = &led0;
+		user-led = &led1;
+	};
+};
+
+&gpiote {
+	status ="ok";
+};
+
+&gpio0 {
+	status ="ok";
+};
+
+&gpio1 {
+	status ="ok";
+};
+
+&uart0 {
+	compatible = "nordic,nrf-uarte";
+	current-speed = <115200>;
+	status = "ok";
+	tx-pin = <6>;
+	rx-pin = <8>;
+};
+
+&adc {
+	status ="ok";
+};
+
+&i2c0 {
+	status = "ok";
+	sda-pin = <58>;
+	scl-pin = <59>;
+};
+
+/*
+ * By default, not adding all available SPI instances (spi0, spi2, spi3) due to
+ * pins not defined for mesh board.
+ */
+&spi1 {
+	status = "ok";
+	sck-pin = <19>;
+	mosi-pin = <20>;
+	miso-pin = <21>;
+};
+
+/* Include flash partition table.
+ * Two partition tables are available:
+ * fstab-stock		-compatible with Nordic nRF5 bootloader, default
+ * fstab-debugger	-to use an external debugger, w/o the nRF5 bootloader
+ */
+#include "fstab-stock.dts"
+
+&usbd {
+	compatible = "nordic,nrf-usbd";
+	status = "ok";
+};

--- a/boards/arm/knot_mesh/knot_mesh.yaml
+++ b/boards/arm/knot_mesh/knot_mesh.yaml
@@ -1,0 +1,22 @@
+#
+# Code based on nrf52840_pca10059.
+# Base commit: 67af71e01d3a5f86efea9eb1f7547be4f8155f31
+# Edited by KNoT contributors.
+#
+
+# Copyright (c) 2019 CESAR
+
+identifier: knot_mesh
+name: KNoT-Mesh
+type: mcu
+arch: arm
+ram: 256
+flash: 1024
+toolchain:
+  - zephyr
+  - gnuarmemb
+  - xtools
+supported:
+  - usb_device
+  - ble
+  - ieee802154

--- a/boards/arm/knot_mesh/knot_mesh_defconfig
+++ b/boards/arm/knot_mesh/knot_mesh_defconfig
@@ -1,0 +1,33 @@
+#
+# Code based on nrf52840_pca10059.
+# Base commit: 38d186a878213e6a5863805c98c20bd81cfb2c84
+# Edited by KNoT contributors.
+#
+
+# Copyright (c) 2019 CESAR
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ARM=y
+CONFIG_SOC_FAMILY_NRF=y
+CONFIG_SOC_SERIES_NRF52X=y
+CONFIG_SOC_NRF52840_QIAA=y
+CONFIG_BOARD_KNOT_MESH=y
+
+# Enable MPU
+CONFIG_ARM_MPU=y
+
+# enable GPIO
+CONFIG_GPIO=y
+
+# Enable UART driver, needed for CDC ACM
+CONFIG_SERIAL=y
+CONFIG_UART_0_NRF_UARTE=y
+CONFIG_UART_INTERRUPT_DRIVEN=y
+
+# enable console
+CONFIG_CONSOLE=y
+
+# additional board options
+CONFIG_GPIO_AS_PINRESET=y
+CONFIG_NFCT_PINS_AS_GPIOS=y


### PR DESCRIPTION
This commit adds support for the knot_mesh board.

The flash partitions are configured to allow migrating from
the stock bootloader to MCUBoot.

The board is based on nrf52840_pca10059's version of commit
38d186a878213e6a5863805c98c20bd81cfb2c84.

Signed-off-by: Joao Cordeiro <jvcc@cesar.org.br>