### PR TITLE
Add I2C, UART0 and UART1 pins for KNoT Mesh

### DIFF
--- a/boards/arm/knot_mesh/knot_mesh.dts
+++ b/boards/arm/knot_mesh/knot_mesh.dts
@@ -90,8 +90,8 @@
 
 &i2c0 {
 	status = "ok";
-	sda-pin = <58>;
-	scl-pin = <59>;
+	sda-pin = <26>;
+	scl-pin = <27>;
 };
 
 /*

--- a/boards/arm/knot_mesh/knot_mesh.dts
+++ b/boards/arm/knot_mesh/knot_mesh.dts
@@ -76,12 +76,27 @@
 	status ="ok";
 };
 
+/*
+ * Map UART0 to unused pins to avoid conflits with logger in
+ * serial communication and map UART1 to external pins to be
+ * used with UART devices.
+ */
 &uart0 {
+	compatible = "nordic,nrf-uarte";
+	current-speed = <115200>;
+	status = "ok";
+	tx-pin = <10>;
+	rx-pin = <11>;
+};
+
+&uart1 {
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;
 	status = "ok";
 	tx-pin = <6>;
 	rx-pin = <8>;
+	rts-pin = <43>;
+	cts-pin = <44>;
 };
 
 &adc {


### PR DESCRIPTION
Change knot_mesh.dts file to support i2c, uart0 and uart1 peripherals for 
KNoT Mesh board.