### PR TITLE
Enable PWM and add ADC in yaml for KNoT Mesh

### DIFF
--- a/boards/arm/knot_mesh/Kconfig.defconfig
+++ b/boards/arm/knot_mesh/Kconfig.defconfig
@@ -48,6 +48,13 @@ config I2C_0
 
 endif # I2C
 
+if PWM
+
+config PWM_0
+	default y
+
+endif # PWM
+
 if SPI
 
 config SPI_1

--- a/boards/arm/knot_mesh/knot_mesh.dts
+++ b/boards/arm/knot_mesh/knot_mesh.dts
@@ -94,6 +94,12 @@
 	scl-pin = <59>;
 };
 
+&pwm0 {
+	status = "ok";
+	ch0-pin = <3>;
+	ch0-inverted;
+};
+
 /*
  * By default, not adding all available SPI instances (spi0, spi2, spi3) due to
  * pins not defined for mesh board.

--- a/boards/arm/knot_mesh/knot_mesh.yaml
+++ b/boards/arm/knot_mesh/knot_mesh.yaml
@@ -20,3 +20,4 @@ supported:
   - usb_device
   - ble
   - ieee802154
+  - pwm

--- a/boards/arm/knot_mesh/knot_mesh.yaml
+++ b/boards/arm/knot_mesh/knot_mesh.yaml
@@ -17,6 +17,7 @@ toolchain:
   - gnuarmemb
   - xtools
 supported:
+  - adc
   - usb_device
   - ble
   - ieee802154


### PR DESCRIPTION
Enable PWM defining the PWM0 as the default PWM and add ADC in YAML for KNoT Mesh.