### PR TITLE
Add I2C, PWM and UART pins for nrf52840_pca10059(USB Dongle)

### DIFF
--- a/boards/arm/nrf52840_pca10059/Kconfig.defconfig
+++ b/boards/arm/nrf52840_pca10059/Kconfig.defconfig
@@ -41,6 +41,13 @@ config I2C_0
 
 endif # I2C
 
+if PWM
+
+config PWM_0
+	default y
+
+endif # PWM
+
 if SPI
 
 config SPI_1

--- a/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
+++ b/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
@@ -77,14 +77,27 @@
 	status ="ok";
 };
 
+/*
+ * Map UART0 to unused pins to avoid conflits with logger in
+ * serial communication and map UART1 to external pins to be
+ * used with UART devices.
+ */
 &uart0 {
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;
 	status = "ok";
-	tx-pin = <20>;
-	rx-pin = <24>;
-	rts-pin = <17>;
-	cts-pin = <22>;
+	tx-pin = <11>;
+	rx-pin = <12>;
+};
+
+&uart1 {
+	compatible = "nordic,nrf-uarte";
+	current-speed = <115200>;
+	status = "ok";
+	tx-pin = <17>;
+	rx-pin = <20>;
+	rts-pin = <22>;
+	cts-pin = <24>;
 };
 
 &adc {

--- a/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
+++ b/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
@@ -104,6 +104,12 @@
 	scl-pin = <31>;
 };
 
+&pwm0 {
+	status = "ok";
+	ch0-pin = <13>;
+	ch0-inverted;
+};
+
 /*
  * By default, not adding all available SPI instances (spi2, spi3) due to
  * limited GPIOs available on dongle board.

--- a/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
+++ b/boards/arm/nrf52840_pca10059/nrf52840_pca10059.dts
@@ -93,8 +93,8 @@
 
 &i2c0 {
 	status = "ok";
-	sda-pin = <26>;
-	scl-pin = <27>;
+	sda-pin = <9>;
+	scl-pin = <10>;
 };
 
 &i2c1 {

--- a/boards/arm/nrf52840_pca10059/nrf52840_pca10059.yaml
+++ b/boards/arm/nrf52840_pca10059/nrf52840_pca10059.yaml
@@ -12,3 +12,4 @@ supported:
   - usb_device
   - ble
   - ieee802154
+  - pwm


### PR DESCRIPTION
Change nrf52840_pca10059.dts file to support pwm, i2c, uart0 and uart1 peripherals for
nrf52840_pca10059 (USB Dongle) board.